### PR TITLE
Fix build.zig v0.15 API breakage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,11 +4,16 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "vulkan-headers",
-        .root_source_file = b.addWriteFiles().add("empty.c", ""),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
+    });
+    lib.root_module.addCSourceFile(.{
+        .file = b.addWriteFiles().add("empty.c", ""),
     });
 
     inline for (.{ "vk_video", "vulkan" }) |subdir| {


### PR DESCRIPTION
Hello,

This change updates the build.zig so that it works after Zig 0.15 made a breaking change to its API, hoping for this to merged so the glfw package can be updated to also work with 0.15.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
